### PR TITLE
updated protocol version to 1.1.5

### DIFF
--- a/MYSKIN/protocol.json
+++ b/MYSKIN/protocol.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "schemaVersion": "0.0.2",
   "name": "mySkin Project",
   "healthIssues": [


### PR DESCRIPTION
Protocol updated due to questionnaire change
1. Just 1 outstanding change please, in 'Special foods or dietary supplements - number of items': error message if 0 is entered is 'Enter a number greater than or equal to 0' but it should read 'Enter a number greater than 0'. (All other error messages for this section are correct)